### PR TITLE
Fix Prefab transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 .idea
+/.vs

--- a/ParallelAnimationSystem/Core/LsMigration.cs
+++ b/ParallelAnimationSystem/Core/LsMigration.cs
@@ -13,16 +13,14 @@ public static class LsMigration
         {
             prefab.Offset = -prefab.Offset;
         }
-        
-        // Clear prefab transforms (ls doesn't support it)
-        // TODO: It actually does, but the code is so cursed that I'm not going to bother
+
+        // Set default scale to 1x1 if X or Y is 0 as this is the default behavior in Legacy.
         foreach (var prefabObject in beatmap.PrefabObjects)
         {
-            prefabObject.Position = System.Numerics.Vector2.Zero;
-            prefabObject.Scale = System.Numerics.Vector2.One;
-            prefabObject.Rotation = 0.0f;
+            if (prefabObject.Scale.X == 0f || prefabObject.Scale.Y == 0f)
+                prefabObject.Scale = System.Numerics.Vector2.One;
         }
-        
+
         // Migrate theme color keyframes
         foreach (var o in beatmap.Objects.Concat(beatmap.Prefabs.SelectMany(x => x.BeatmapObjects)))
         {

--- a/ParallelAnimationSystem/Core/VgMigration.cs
+++ b/ParallelAnimationSystem/Core/VgMigration.cs
@@ -9,6 +9,13 @@ public static class VgMigration
 {
     public static void MigrateBeatmap(IBeatmap beatmap)
     {
+        // Set default scale to 1x1 if X and Y is 0 as this is the default behavior in alpha.
+        foreach (var prefabObject in beatmap.PrefabObjects)
+        {
+            if (prefabObject.Scale.X == 0f && prefabObject.Scale.Y == 0f)
+                prefabObject.Scale = System.Numerics.Vector2.One;
+        }
+
         // Migrate theme color keyframes
         foreach (var o in beatmap.Objects.Concat(beatmap.Prefabs.SelectMany(x => x.BeatmapObjects)))
         {


### PR DESCRIPTION
Prefab Objects in Legacy and Alpha handle the scale transform differently.
With Legacy: scale sets to 1x1 if one of the axis is 0
With Alpha: scale sets to 1x1 if both of the axis is 0

Additionally, some Legacy levels do use Prefab transforms, such as [Crystal Tokyo](https://steamcommunity.com/sharedfiles/filedetails/?id=2183599162), however this will need to be implemented to Pamx as well.